### PR TITLE
Use multi-stage build pattern with a lighter base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM python:3
-
+FROM python:3-slim-stretch AS image-builder
 WORKDIR /usr/src/app
-
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
-
 COPY . .
 
+FROM gcr.io/distroless/python3
+COPY --from=image-builder /usr/src/app /app
+WORKDIR /app
 CMD [ "python", "./server.py" ]


### PR DESCRIPTION
Reference #1 

Here's the result of using a lighter image
```
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
jithub              latest              f967db120e00        17 seconds ago      50.9MB
```

I won't even count the percent of improvement, figures are enough.

Main idea was to use a light but already enough builder in `slim-stretch` and then use a priviledges less image to run it in `distroless` initiative from **Google**